### PR TITLE
Form label add Chip 任意表示

### DIFF
--- a/src/components/Button/ButtonWrap.tsx
+++ b/src/components/Button/ButtonWrap.tsx
@@ -27,7 +27,7 @@ export const ButtonWrap = ({ sx, children, justifyContent }: Props) => {
   return (
     <>
       <StackButtonWrap
-        justifyContent={justifyContent ? justifyContent : "flex-start"}
+        justifyContent={justifyContent ? justifyContent : 'flex-start'}
         sx={sx}
       >
         {children}

--- a/src/components/Button/ButtonWrap.tsx
+++ b/src/components/Button/ButtonWrap.tsx
@@ -27,7 +27,7 @@ export const ButtonWrap = ({ sx, children, justifyContent }: Props) => {
   return (
     <>
       <StackButtonWrap
-        justifyContent={justifyContent ? justifyContent : 'flex-end'}
+        justifyContent={justifyContent ? justifyContent : "flex-start"}
         sx={sx}
       >
         {children}

--- a/src/components/Button/CustomButton.tsx
+++ b/src/components/Button/CustomButton.tsx
@@ -7,13 +7,13 @@ type Props = {
   children: ReactNode // 必須
   // Button Style = Partial
   color?:
-  | 'inherit'
-  | 'primary'
-  | 'secondary'
-  | 'success'
-  | 'error'
-  | 'info'
-  | 'warning' // 初期値: primary
+    | 'inherit'
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'error'
+    | 'info'
+    | 'warning' // 初期値: primary
   size?: 'small' | 'medium' | 'large' // 初期値: medium
   variant?: 'contained' | 'outlined' | 'text' // 初期値: contained
   type?: 'submit' | 'reset' | 'button' // 初期値: Submit *Submitさせたくない時は'button'などを指定

--- a/src/components/Form/CustomLabel.tsx
+++ b/src/components/Form/CustomLabel.tsx
@@ -24,6 +24,10 @@ const Label = styled(InputLabel)(() => ({
   textAlign: 'left',
   transform: 'none',
   minHeight: '1.85em',
+
+  '&.MuiFormLabel-root.MuiInputLabel-root': {
+    fontSize: 14,
+  },
 }))
 
 export const CustomLabel = ({

--- a/src/components/Form/CustomLabel.tsx
+++ b/src/components/Form/CustomLabel.tsx
@@ -9,7 +9,7 @@ type Props = {
   TooltipTitleIconComponent?: ReactNode // ツールチップに表示するアイコンとセット。ツールチップ内にテキストかコンポーネントを設置可能。
   TooltipComponent?: ReactNode // トリガーをアイコンでなくテキストを設定する場合はtrue default: false
   children: ReactNode
-  OptionalRequired?: ReactNode
+  OptionalChip?: ReactNode
   chipLabel?: string
   size?: 'medium' | 'small'
   color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'
@@ -31,7 +31,7 @@ export const CustomLabel = ({
   TooltipTitleIconComponent,
   TooltipComponent,
   children,
-  OptionalRequired,
+  OptionalChip,
   chipLabel,
   color,
   size,
@@ -46,7 +46,7 @@ export const CustomLabel = ({
           TooltipTitleIconComponent={TooltipTitleIconComponent}
           TooltipComponent={TooltipComponent}
         />
-        {OptionalRequired && (
+        {OptionalChip && (
           <Chip
             size={size ? size : 'small'}
             color={color}

--- a/src/components/Form/CustomLabel.tsx
+++ b/src/components/Form/CustomLabel.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 const Label = styled(InputLabel)(() => ({
   marginTop: 24,
-  fontcolor: '14px',
+  fontSize: '14px',
   position: 'initial',
   textAlign: 'left',
   transform: 'none',

--- a/src/components/Form/CustomLabel.tsx
+++ b/src/components/Form/CustomLabel.tsx
@@ -1,6 +1,6 @@
-import { InputLabel, styled } from '@mui/material'
-import { CustomTooltip } from 'components/Tooltip/CustomTooltip'
-import { ReactNode } from 'react'
+import { Chip, InputLabel, styled } from "@mui/material"
+import { CustomTooltip } from "components/Tooltip/CustomTooltip"
+import { ReactNode } from "react"
 
 // Types
 type Props = {
@@ -8,15 +8,17 @@ type Props = {
   TooltipTitleIconComponent?: ReactNode // ツールチップに表示するアイコンとセット。ツールチップ内にテキストかコンポーネントを設置可能。
   TooltipComponent?: ReactNode // トリガーをアイコンでなくテキストを設定する場合はtrue default: false
   children: ReactNode
+  OptionalRequired?: ReactNode
+  chipLabel?: string
 }
 
 const Label = styled(InputLabel)(() => ({
   marginTop: 24,
-  fontSize: '14px',
-  position: 'initial',
-  textAlign: 'left',
-  transform: 'none',
-  minHeight: '1.85em',
+  fontSize: "14px",
+  position: "initial",
+  textAlign: "left",
+  transform: "none",
+  minHeight: "1.85em",
 }))
 
 export const CustomLabel = ({
@@ -24,6 +26,8 @@ export const CustomLabel = ({
   TooltipTitleIconComponent,
   TooltipComponent,
   children,
+  OptionalRequired,
+  chipLabel,
 }: Props) => {
   return (
     <>
@@ -33,6 +37,13 @@ export const CustomLabel = ({
           TooltipTitleIconComponent={TooltipTitleIconComponent}
           TooltipComponent={TooltipComponent}
         />
+        {OptionalRequired && (
+          <Chip
+            size='small'
+            label={chipLabel ? chipLabel : "任意"}
+            style={{ borderRadius: 4, marginBottom: 1 }}
+          />
+        )}
       </Label>
     </>
   )

--- a/src/components/Form/CustomLabel.tsx
+++ b/src/components/Form/CustomLabel.tsx
@@ -1,6 +1,7 @@
-import { Chip, InputLabel, styled } from "@mui/material"
-import { CustomTooltip } from "components/Tooltip/CustomTooltip"
-import { ReactNode } from "react"
+import { Chip, InputLabel, styled } from '@mui/material'
+import { CustomTooltip } from 'components/Tooltip/CustomTooltip'
+import { ReactNode } from 'react'
+import { SxProps } from '@mui/system'
 
 // Types
 type Props = {
@@ -10,15 +11,19 @@ type Props = {
   children: ReactNode
   OptionalRequired?: ReactNode
   chipLabel?: string
+  size?: 'medium' | 'small'
+  color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'
+  variant?: 'filled' | 'outlined'
+  sx?: SxProps
 }
 
 const Label = styled(InputLabel)(() => ({
   marginTop: 24,
-  fontSize: "14px",
-  position: "initial",
-  textAlign: "left",
-  transform: "none",
-  minHeight: "1.85em",
+  fontcolor: '14px',
+  position: 'initial',
+  textAlign: 'left',
+  transform: 'none',
+  minHeight: '1.85em',
 }))
 
 export const CustomLabel = ({
@@ -28,6 +33,10 @@ export const CustomLabel = ({
   children,
   OptionalRequired,
   chipLabel,
+  color,
+  size,
+  sx,
+  variant,
 }: Props) => {
   return (
     <>
@@ -39,9 +48,16 @@ export const CustomLabel = ({
         />
         {OptionalRequired && (
           <Chip
-            size='small'
-            label={chipLabel ? chipLabel : "任意"}
-            style={{ borderRadius: 4, marginBottom: 1 }}
+            size={size ? size : 'small'}
+            color={color}
+            variant={variant}
+            label={chipLabel ? chipLabel : '任意'}
+            sx={sx}
+            style={{
+              borderRadius: 4,
+              margin: `0px 4px 4px`,
+              padding: `1px 8px 0`,
+            }}
           />
         )}
       </Label>

--- a/src/components/Text/TitleSet.tsx
+++ b/src/components/Text/TitleSet.tsx
@@ -16,29 +16,29 @@ import { ElementType, ReactNode } from 'react'
 // INFO: *variantのh1はMainTitleSetでのみ設置可能としたいです
 type TitleSetProps = Partial<{
   variant:
-  | 'h2'
-  | 'h3'
-  | 'h4'
-  | 'h5'
-  | 'h6'
-  | 'body1'
-  | 'body2'
-  | 'button'
-  | 'caption'
-  | 'overline'
-  | 'inherit'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'body1'
+    | 'body2'
+    | 'button'
+    | 'caption'
+    | 'overline'
+    | 'inherit'
   component: ElementType
   headingText: string
   subtitleText: string
   variantSubTitle:
-  | 'subtitle1'
-  | 'subtitle2'
-  | 'body1'
-  | 'body2'
-  | 'button'
-  | 'caption'
-  | 'overline'
-  | 'inherit'
+    | 'subtitle1'
+    | 'subtitle2'
+    | 'body1'
+    | 'body2'
+    | 'button'
+    | 'caption'
+    | 'overline'
+    | 'inherit'
   AdditionalProps: JSX.Element
   sxHeader: SxProps
   sxSubTitle: SxProps
@@ -88,10 +88,10 @@ const TitleSet = ({
           margin: noMargin
             ? theme.spacing(0)
             : mbSmall
-              ? theme.spacing(0, 0, 1, 0)
-              : mbLarge
-                ? theme.spacing(0, 0, 5, 0)
-                : theme.spacing(0, 0, 3, 0),
+            ? theme.spacing(0, 0, 1, 0)
+            : mbLarge
+            ? theme.spacing(0, 0, 5, 0)
+            : theme.spacing(0, 0, 3, 0),
           '.MuiPageTitle-wrapper': {
             m: theme.spacing(0),
             p: theme.spacing(0),

--- a/src/components/Tooltip/CustomTooltip.tsx
+++ b/src/components/Tooltip/CustomTooltip.tsx
@@ -17,26 +17,26 @@ export const CustomTooltip = ({
       {TooltipTitleIconComponent && (
         <Tooltip
           title={
-            <Box sx={{ textAlign: 'justify' }}>{TooltipTitleIconComponent}</Box>
+            <Box sx={{ textAlign: "justify" }}>{TooltipTitleIconComponent}</Box>
           }
           arrow
-          placement="top-start"
+          placement='top-start'
         >
           <Button
             sx={{
-              margin: '0 0 .2em 0',
-              '&.MuiButton-root': {
-                margin: '0 2px 2px',
-                minWidth: 'fit-content',
-                padding: '3px 6px 3px',
-                borderRadius: '6px',
+              margin: "0 0 .2em 0",
+              "&.MuiButton-root": {
+                margin: "0 2px 4px",
+                minWidth: "fit-content",
+                padding: "2px 4px",
+                borderRadius: "6px",
               },
             }}
           >
             {TooltipComponent ? (
               TooltipComponent
             ) : (
-              <HelpOutlineIcon fontSize="small" />
+              <HelpOutlineIcon fontSize='small' />
             )}
           </Button>
         </Tooltip>

--- a/src/components/Tooltip/CustomTooltip.tsx
+++ b/src/components/Tooltip/CustomTooltip.tsx
@@ -17,26 +17,26 @@ export const CustomTooltip = ({
       {TooltipTitleIconComponent && (
         <Tooltip
           title={
-            <Box sx={{ textAlign: "justify" }}>{TooltipTitleIconComponent}</Box>
+            <Box sx={{ textAlign: 'justify' }}>{TooltipTitleIconComponent}</Box>
           }
           arrow
-          placement='top-start'
+          placement="top-start"
         >
           <Button
             sx={{
-              margin: "0 0 .2em 0",
-              "&.MuiButton-root": {
-                margin: "0 2px 4px",
-                minWidth: "fit-content",
-                padding: "2px 4px",
-                borderRadius: "6px",
+              margin: '0 0 .2em 0',
+              '&.MuiButton-root': {
+                margin: '0 2px 4px',
+                minWidth: 'fit-content',
+                padding: '2px 4px',
+                borderRadius: '6px',
               },
             }}
           >
             {TooltipComponent ? (
               TooltipComponent
             ) : (
-              <HelpOutlineIcon fontSize='small' />
+              <HelpOutlineIcon fontSize="small" />
             )}
           </Button>
         </Tooltip>


### PR DESCRIPTION
# Check List
- [x] Projects に`SaaSus-platform` を紐づけ
- [x] Linked issues に issue を紐付け
https://github.com/Anti-Pattern-Inc/saasus-theme/issues/19

## What's Changed
- ラベルのチップ設置
　- 任意、その他のカスタムChip
- Button Componentドキュメントを独立ページに移動、再編集

## Linked Issues
- https://github.com/Anti-Pattern-Inc/saasus-theme/issues/19

## Screenshots

### Old

### New

![image](https://user-images.githubusercontent.com/10333049/193905000-a804f553-7521-4ab8-af51-20f00226c0bf.png)

Button Component
![image](https://user-images.githubusercontent.com/10333049/193887148-646ea71b-fb07-4a65-b86e-7a8307cddde2.png)
