### PR TITLE
saasus-themeのビルドファイルをGitブランチで配布するように（追加）

### DIFF
--- a/.github/workflows/publish-build-files.yml
+++ b/.github/workflows/publish-build-files.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Commit files
         run: |
+          git fetch origin
           git checkout main
           git add dist
           git commit -a -m "update dist"


### PR DESCRIPTION
# Check List
- [x] Projects に`SaaSus-platform` を紐づけ
- [x] Linked issues に issue を紐付け

## What's Changed
- Github Actionsでdevelopにpushされやときにdistディレクトリをコミット
- develop <- 開発ブランチ
- main <- デフォルトブランチ

## Linked Issues
- https://github.com/Anti-Pattern-Inc/saasus-theme/issues/25