### PR TITLE
saasus-themeのビルドファイルをGitブランチで配布するように (git add --force)

### DIFF
--- a/.github/workflows/publish-build-files.yml
+++ b/.github/workflows/publish-build-files.yml
@@ -33,13 +33,12 @@ jobs:
         run: |
           git config --local user.email "y@anti-pattern.co.jp"
           git config --local user.name "Akihiro YAGASAKI"
-          git config advice.addIgnoredFile false
 
       - name: Commit files
         run: |
           git fetch origin
           git checkout main
-          git add dist
+          git add -f dist
           git commit -a -m "update dist"
           git pull
           git push origin main


### PR DESCRIPTION
# Check List
- [x] Projects に`SaaSus-platform` を紐づけ
- [x] Linked issues に issue を紐付け

## What's Changed
- Github Actionsでdevelopにpushされやときにdistディレクトリをコミット
- develop <- 開発ブランチ
- main <- デフォルトブランチ

## Linked Issues
- https://github.com/Anti-Pattern-Inc/saasus-theme/issues/25